### PR TITLE
Fix V3008

### DIFF
--- a/GhostRunner.SL/ScheduleService.cs
+++ b/GhostRunner.SL/ScheduleService.cs
@@ -112,9 +112,8 @@ namespace GhostRunner.SL
                 else if (type.Trim().ToLower() == "weekly") schedule.ScheduleType = ScheduleType.Weekly;
                 else if (type.Trim().ToLower() == "monthly") schedule.ScheduleType = ScheduleType.Monthly;
 
-                if (itemType.Trim().ToLower() == "sequence") {
-                    schedule.ScheduleItemType = ItemType.Sequence;
-
+                if (itemType.Trim().ToLower() == "sequence") 
+                {
                     Sequence sequence = null;
 
                     try
@@ -133,8 +132,6 @@ namespace GhostRunner.SL
                 }
                 else if (itemType.Trim().ToLower() == "script")
                 {
-                    schedule.ScheduleItemType = ItemType.Script;
-
                     Script script = null;
 
                     try


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- The 'schedule.ScheduleItemType' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 131, 116. GhostRunner.SL ScheduleService.cs 131

- The 'schedule.ScheduleItemType' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 151, 136. GhostRunner.SL ScheduleService.cs 151